### PR TITLE
Removed static qualifier from TimelyEvalutor._cachedPoints

### DIFF
--- a/timelytextview/src/main/java/com/github/adnansm/timelytextview/animation/TimelyEvaluator.java
+++ b/timelytextview/src/main/java/com/github/adnansm/timelytextview/animation/TimelyEvaluator.java
@@ -3,7 +3,7 @@ package com.github.adnansm.timelytextview.animation;
 import com.nineoldandroids.animation.TypeEvaluator;
 
 public class TimelyEvaluator implements TypeEvaluator<float[][]> {
-    private static float[][] _cachedPoints = null;
+    private float[][] _cachedPoints = null;
 
     @Override
     public float[][] evaluate(float fraction, float[][] startValue, float[][] endValue) {


### PR DESCRIPTION
By having this static, the same points are cached for all views. If you have multiple views running, the actual result is not what you'd expect (all animate to the same number, not different ones).
